### PR TITLE
Updated code to only replace close tag text if it is different.

### DIFF
--- a/LitSyntaxHighlighter/Tagger/LitTemplateAutoTagger.cs
+++ b/LitSyntaxHighlighter/Tagger/LitTemplateAutoTagger.cs
@@ -132,7 +132,7 @@ namespace LitSyntaxHighlighter.Tagger
                     if (options.AutoRenameClosingTags && selectedCloseTag.HasValue && selectedCloseTag.Value.Key is var selectedCloseSpan)
                     {
                         var closeTagSpan = selectedCloseSpan.TranslateTo(change.Snapshot, SpanTrackingMode.EdgeInclusive);
-                        if (newName.All(c => _tagManager.IsNameChar(c)))
+                        if (newName.All(c => _tagManager.IsNameChar(c)) && closeTagSpan.GetText() != newName)
                         {
                             // Replace old close tag name directly with new open tag name
                             sourceBuffer.Replace(closeTagSpan.Span, newName);

--- a/LitSyntaxHighlighter/Tagger/LitTemplateTagManager.cs
+++ b/LitSyntaxHighlighter/Tagger/LitTemplateTagManager.cs
@@ -1,6 +1,5 @@
 ﻿using LitSyntaxHighlighter.Utility;
 using Microsoft.VisualStudio.Text;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -32,6 +31,7 @@ namespace LitSyntaxHighlighter.Tagger
 
         private readonly Regex _openTemplateRegex = new Regex("html`", RegexOptions.IgnoreCase);
         private readonly Regex _closeTemplateRegex = new Regex("(`|{|}|\")", RegexOptions.IgnoreCase);
+        private readonly string _allowedSymbolsBetweenTags = "!@#$%^&*()-_{}[]|/=+.,;:\"\'~";
 
         private SortedDictionary<SnapshotSpan, TagType> _tagCache;
         private ITextSnapshot _currentSnapshot;
@@ -120,7 +120,7 @@ namespace LitSyntaxHighlighter.Tagger
 
         public bool IsTextChar(char c)
         {
-            return c == '_' || char.IsLetterOrDigit(c);
+            return _allowedSymbolsBetweenTags.Contains(c) || char.IsLetterOrDigit(c);
         }
 
         public void TryUpdateSelectedClassification(SnapshotPoint selectionPoint)
@@ -410,7 +410,8 @@ namespace LitSyntaxHighlighter.Tagger
                         }
                     case '"':
                         {
-                            if (state.Peek() >= TemplateState.InsideTemplate)
+                            var peek = state.Peek();
+                            if (peek >= TemplateState.InsideTemplate && peek != TemplateState.BetweenTags && peek != TemplateState.BetweenTagsText)
                             {
                                 state.Push(TemplateState.PauseString);
                             }


### PR DESCRIPTION
1. Added check to only replace close tag name if it is different.
2. Added additional parsing to allow symbols between tags